### PR TITLE
Correct private to Private

### DIFF
--- a/_site/index.html
+++ b/_site/index.html
@@ -111,7 +111,7 @@
 					DevOps pipeline using <a href="https://jenkins.io/">Jenkins</a>.
 					Microclimate can be installed locally or on <a
 						href="https://www.ibm.com/cloud-computing/products/ibm-cloud-private/">IBM
-						Cloud private</a>.
+						Cloud Private</a>.
 				</h1>
 			</div>
 

--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@ home: true
 					DevOps pipeline using <a href="https://jenkins.io/">Jenkins</a>.
 					Microclimate can be installed locally or on <a
 						href="https://www.ibm.com/cloud-computing/products/ibm-cloud-private/">IBM
-						Cloud private</a>.
+						Cloud Private</a>.
 				</h1>
 			</div>
 


### PR DESCRIPTION
IBM Cloud private -> IBM Cloud Private. 

Correct issue raised by yeekangc:
https://github.com/microclimate-dev2ops/microclimate-dev2ops.github.io/issues/2